### PR TITLE
MDL-78749

### DIFF
--- a/mod/quiz/classes/output/renderer.php
+++ b/mod/quiz/classes/output/renderer.php
@@ -1103,6 +1103,8 @@ class renderer extends plugin_renderer_base {
         // Prepare table header.
         $table = new html_table();
         $table->attributes['class'] = 'generaltable quizattemptsummary';
+        $table->caption = get_string('summaryofattempts', 'quiz');
+        $table->captionhide = true;
         $table->head = [];
         $table->align = [];
         $table->size = [];


### PR DESCRIPTION
### Accessibility\Quiz: Previous attempt summary table caption missing

**Description**
The table with the title' Summary of your previous attempts' does not have a programmatically associated caption or a table name. A caption is read out by screen readers to provide users with a quick summary of what the table covers. The recommendation is to use the table title 'Summary of your previous attempts' as the table <caption> tag so that screen reader users can understand the purpose of the table.